### PR TITLE
Give the CD workflow permission to publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '**'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     name: "Publish Docker Image"


### PR DESCRIPTION
Add permissions to the workflow to allow it to publish to ghcr.io
